### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -378,3 +378,7 @@ jd_jx_mc_zn_exchange.js
 jd_GoldcoinToGift.js
 jd_ftzy.js
 jd_aid_ftzy.js
+
+#京东农场任务重复
+jd_fruit_task.js
+jd_fruit_friend.js


### PR DESCRIPTION
jd_fruit.js 更新日期是2021-11-07 看运行日志是已经包含日常任务jd_fruit_task.js和农场删好友奖励jd_fruit_friend.js